### PR TITLE
Feature/line primitive meshes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,235 @@
+---
+BasedOnStyle: WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseColons: false
+AlignEscapedNewlines: Right
+AlignOperands: DontAlign
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 0
+CommentPragmas: "^ IWYU pragma:"
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: ^"(llvm|llvm-c|clang|clang-c)/
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: ^(<|"(gtest|gmock|isl|json)/)
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: .*
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: (Test)?$
+IncludeIsMainSourceRegex: ""
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtEOF: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+Language: Cpp
+LineEnding: DeriveLF
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PPIndentWidth: -1
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes: CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 8
+UseTab: Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+

--- a/include/model_loader.hpp
+++ b/include/model_loader.hpp
@@ -47,31 +47,34 @@ struct Mesh
     [[nodiscard]] uint32_t GetIndicesPerFaceNum() const;
 };
 
+struct SceneGraph
+{
+    SceneGraph() = default;
+    NON_COPYABLE(SceneGraph) // If we copied, node parent pointers would be invalidated
+
+    std::string sceneName {};
+    std::vector<Node> nodes {}; // TODO: Nodes themselves are still copyable, but we just overlook this for now (maybe make this vector a pointer?)
+    std::vector<Mesh> meshes {};
+    std::vector<ResourceHandle<Image>> textures {};
+    std::vector<ResourceHandle<Material>> materials {};
+};
+
 struct ModelCreation
 {
     std::vector<Mesh::Vertex> vertexBuffer {};
     std::vector<uint32_t> indexBuffer {};
-
-    std::string sceneName {};
-    std::vector<Node> nodes {};
-    std::vector<Mesh> meshes {};
-    std::vector<ResourceHandle<Image>> textures {};
-    std::vector<ResourceHandle<Material>> materials {};
+    std::shared_ptr<SceneGraph> sceneGraph {};
 };
 
 struct Model
 {
     Model(const ModelCreation& creation, const std::shared_ptr<VulkanContext>& vulkanContext);
 
-    std::unique_ptr<Buffer> vertexBuffer;
-    std::unique_ptr<Buffer> indexBuffer;
+    std::unique_ptr<Buffer> vertexBuffer {};
+    std::unique_ptr<Buffer> indexBuffer {};
     uint32_t verticesCount {};
     uint32_t indexCount {};
-
-    std::vector<Node> nodes {};
-    std::vector<Mesh> meshes {};
-    std::vector<ResourceHandle<Image>> textures {};
-    std::vector<ResourceHandle<Material>> materials {};
+    std::shared_ptr<SceneGraph> sceneGraph {};
 };
 
 class ModelLoader

--- a/include/model_loader.hpp
+++ b/include/model_loader.hpp
@@ -25,6 +25,13 @@ struct Node
 
 struct Mesh
 {
+    struct Vertex
+    {
+        glm::vec3 position {};
+        glm::vec3 normal {};
+        glm::vec2 texCoord {};
+    };
+
     enum class PrimitiveType : uint8_t
     {
         eTriangles,
@@ -40,14 +47,21 @@ struct Mesh
     [[nodiscard]] uint32_t GetIndicesPerFaceNum() const;
 };
 
+struct ModelCreation
+{
+    std::vector<Mesh::Vertex> vertexBuffer {};
+    std::vector<uint32_t> indexBuffer {};
+
+    std::string sceneName {};
+    std::vector<Node> nodes {};
+    std::vector<Mesh> meshes {};
+    std::vector<ResourceHandle<Image>> textures {};
+    std::vector<ResourceHandle<Material>> materials {};
+};
+
 struct Model
 {
-    struct Vertex
-    {
-        glm::vec3 position {};
-        glm::vec3 normal {};
-        glm::vec2 texCoord {};
-    };
+    Model(const ModelCreation& creation, const std::shared_ptr<VulkanContext>& vulkanContext);
 
     std::unique_ptr<Buffer> vertexBuffer;
     std::unique_ptr<Buffer> indexBuffer;
@@ -71,7 +85,8 @@ public:
     [[nodiscard]] std::shared_ptr<Model> LoadFromFile(std::string_view path);
 
 private:
-    [[nodiscard]] std::shared_ptr<Model> ProcessModel(const aiScene* scene, const std::string_view directory);
+    [[nodiscard]] ModelCreation LoadModel(const aiScene* scene, const std::string_view directory);
+    [[nodiscard]] std::shared_ptr<Model> ProcessModel(const ModelCreation& modelCreation);
 
     Assimp::Importer _importer {};
     std::unordered_map<std::string_view, ResourceHandle<Image>> _imageCache {};

--- a/include/model_loader.hpp
+++ b/include/model_loader.hpp
@@ -25,10 +25,19 @@ struct Node
 
 struct Mesh
 {
+    enum class PrimitiveType : uint8_t
+    {
+        eTriangles,
+        eLines,
+    };
+
+    PrimitiveType primitiveType = PrimitiveType::eTriangles;
     uint32_t indexCount {};
     uint32_t firstIndex {};
     uint32_t firstVertex {};
     ResourceHandle<Material> material {};
+
+    [[nodiscard]] uint32_t GetIndicesPerFaceNum() const;
 };
 
 struct Model

--- a/source/model_loader.cpp
+++ b/source/model_loader.cpp
@@ -354,8 +354,7 @@ Model::Model(const ModelCreation& creation, const std::shared_ptr<VulkanContext>
         commands.Record([&](vk::CommandBuffer commandBuffer)
             {
                 VkCopyBufferToBuffer(commandBuffer, vertexStagingBuffer.buffer, vertexBuffer->buffer, sizeof(Mesh::Vertex) * creation.vertexBuffer.size());
-                VkCopyBufferToBuffer(commandBuffer, indexStagingBuffer.buffer, indexBuffer->buffer, sizeof(uint32_t) * creation.indexBuffer.size());
-            });
+                VkCopyBufferToBuffer(commandBuffer, indexStagingBuffer.buffer, indexBuffer->buffer, sizeof(uint32_t) * creation.indexBuffer.size()); });
         commands.SubmitAndWait();
     }
 }
@@ -468,40 +467,40 @@ std::shared_ptr<Model> ModelLoader::ProcessModel(const ModelCreation& modelCreat
         for (const LineSegment& segment : lineSegments)
         {
             static const std::vector<uint32_t> indices {
-                //Top
+                // Top
                 2, 6, 7,
                 2, 3, 7,
 
-                //Bottom
+                // Bottom
                 0, 4, 5,
                 0, 1, 5,
 
-                //Left
+                // Left
                 0, 2, 6,
                 0, 4, 6,
 
-                //Right
+                // Right
                 1, 3, 7,
                 1, 5, 7,
 
-                //Front
+                // Front
                 0, 2, 3,
                 0, 1, 3,
 
-                //Back
+                // Back
                 4, 6, 7,
                 4, 5, 7
             };
 
             static const std::vector<glm::vec3> vertices {
-                glm::vec3(-1, -1,  1.0), //0
-                 glm::vec3(1, -1,  1.0), //1
-                glm::vec3(-1,  1,  1.0), //2
-                 glm::vec3(1,  1,  1.0), //3
-                glm::vec3(-1, -1, -1.0), //4
-                 glm::vec3(1, -1, -1.0), //5
-                glm::vec3(-1,  1, -1.0), //6
-                 glm::vec3(1,  1, -1.0)  //7
+                glm::vec3(-1, -1, 1.0), // 0
+                glm::vec3(1, -1, 1.0), // 1
+                glm::vec3(-1, 1, 1.0), // 2
+                glm::vec3(1, 1, 1.0), // 3
+                glm::vec3(-1, -1, -1.0), // 4
+                glm::vec3(1, -1, -1.0), // 5
+                glm::vec3(-1, 1, -1.0), // 6
+                glm::vec3(1, 1, -1.0) // 7
             };
 
             constexpr float boxSize = 0.02f;
@@ -514,7 +513,7 @@ std::shared_ptr<Model> ModelLoader::ProcessModel(const ModelCreation& modelCreat
 
             for (glm::vec3 pos : vertices)
             {
-                newVertexBuffer.push_back({pos * boxSize + segment.start});
+                newVertexBuffer.push_back({ pos * boxSize + segment.start });
             }
 
             newMesh.indexCount += indices.size();

--- a/source/renderer.cpp
+++ b/source/renderer.cpp
@@ -28,7 +28,7 @@ Renderer::Renderer(const VulkanInitInfo& initInfo, const std::shared_ptr<VulkanC
     };
     for (const auto& modelPath : scene)
     {
-        _models.push_back(_modelLoader->LoadFromFile(modelPath));
+        _models.emplace_back(_modelLoader->LoadFromFile(modelPath));
     }
     InitializeBLAS();
 
@@ -420,7 +420,7 @@ BLASInput InitializeBLASInput(const std::shared_ptr<Model>& model, const Node& n
     trianglesData.vertexFormat = vk::Format::eR32G32B32Sfloat;
     trianglesData.vertexData = vertexBufferDeviceAddress;
     trianglesData.maxVertex = model->verticesCount - 1;
-    trianglesData.vertexStride = sizeof(Model::Vertex);
+    trianglesData.vertexStride = sizeof(Mesh::Vertex);
     trianglesData.indexType = vk::IndexType::eUint32;
     trianglesData.indexData = indexBufferDeviceAddress;
     trianglesData.transformData = {}; // Identity transform

--- a/source/renderer.cpp
+++ b/source/renderer.cpp
@@ -24,7 +24,7 @@ Renderer::Renderer(const VulkanInitInfo& initInfo, const std::shared_ptr<VulkanC
     _modelLoader = std::make_unique<ModelLoader>(_bindlessResources, _vulkanContext);
 
     const std::vector<std::string> scene = {
-        "assets/helmet/FlightHelmet.gltf",
+        "assets/claire/Claire_HairMain_HQ.gltf",
     };
     for (const auto& modelPath : scene)
     {
@@ -176,7 +176,7 @@ void Renderer::InitializeCamera()
 
     CameraUniformData cameraData {};
     cameraData.projInverse = glm::inverse(projection);
-    cameraData.viewInverse = glm::inverse(glm::lookAt(glm::vec3(0.0f, 1.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f)));
+    cameraData.viewInverse = glm::inverse(glm::lookAt(glm::vec3(15.0f, 150.0f, 25.0f), glm::vec3(-6.0f, 151.0f, -1.2f), glm::vec3(0.0f, 1.0f, 0.0f)));
 
     constexpr vk::DeviceSize uniformBufferSize = sizeof(CameraUniformData);
     BufferCreation uniformBufferCreation {};
@@ -450,11 +450,13 @@ void Renderer::InitializeBLAS()
 {
     for (const auto& model : _models)
     {
-        for (const auto& node : model->nodes)
+        std::shared_ptr<SceneGraph> sceneGraph = model->sceneGraph;
+
+        for (const auto& node : sceneGraph->nodes)
         {
             for (const auto mesh : node.meshes)
             {
-                BLASInput input = InitializeBLASInput(model, node, model->meshes[mesh], _vulkanContext);
+                BLASInput input = InitializeBLASInput(model, node, sceneGraph->meshes[mesh], _vulkanContext);
                 _blases.emplace_back(input, _bindlessResources, _vulkanContext);
             }
         }


### PR DESCRIPTION
### Description

- Adds line primitive meshes for hair
- Adds simple visualization for hair strands by making a mesh out of the lines
- Split model loading from file and model creation ready for GPU use to make pre-processing the mesh easier
- Adds `SceneGraph` structure that holds scene information without the actual geometry, which avoids copying data, invalidating pointers in nodes in the scene and makes a nice separation of concerns

<img width="838" height="852" alt="image" src="https://github.com/user-attachments/assets/8a20b6c9-1048-4234-b38b-54898d7d7d75" />
